### PR TITLE
Use posixpath instead of os.path

### DIFF
--- a/iocitrix.py
+++ b/iocitrix.py
@@ -7,7 +7,7 @@
 # author: Fox-IT Security Research Team <srt@fox-it.com>
 #
 import argparse
-import os
+import posixpath
 import re
 from typing import Iterator
 
@@ -111,7 +111,7 @@ def check_suspicious_php_files(target: Target, start_path) -> Iterator[FindingRe
         return
     for directory, _, files in target.fs.walk(start_path):
         for file in files:
-            path = os.path.join(directory, file)
+            path = posixpath.join(directory, file)
             if not file.endswith(".php"):
                 continue
             if (target.fs.stat(path).st_mode & 0o777) != EXPECTED_PHP_FILE_PERMISSION:


### PR DESCRIPTION
I ran into errors similar to the following when running `iocitrix.py` on a Windows host:

```
dissect.target.exceptions.FileNotFoundError: /var/netscaler/ns_gui/admin_ui/common/gen/php\_ns_stat_definitions.php
Collapse
```

The exported images will always use posix style paths, so `posixpath.join` can be used instead of `os.path.join` to prevent `\` separators being used.