### PR TITLE
Pin Dissect at version 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tabulate
-dissect>=3.8.1
+dissect==3.9


### PR DESCRIPTION
Due to changes to Dissect's handling of volumes, Dissect 3.10 does not properly handle volumes at offset 0 (see also https://github.com/fox-it/dissect.target/pull/443). As this is often encountered for Citrix Netscalers, this PR suggests pinning the Dissect version at 3.9 for now.