### PR TITLE
fixed version enum values in print statement

### DIFF
--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -331,7 +331,7 @@ def main() -> None:
             print(f"{target}: {version.error}")
         elif version.version == "unknown":
             print(
-                f"{target} is running an unknown version (stamp={version.stamp}, dt={version.dt})"
+                f"{target} is running an unknown version (stamp={version.rdx_en_stamp}, dt={version.rdx_en_dt})"
             )
         else:
             print(f"{target} is running Citrix NetScaler version {version.version}")


### PR DESCRIPTION
If json output is not used and version is unknown, this crashes the script. Fixed by using the correct classvars.