### PR TITLE
Add more NetScaler version stamps and improvements to scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ You can use this script to scan and determine the version of a Citrix NetScaler 
 
 ## Installing `scan-citrix-netscaler-version.py`
 
-Use the following steps:
+Use the following steps if you are using pip:
 
 1. git clone https://github.com/fox-it/citrix-netscaler-triage.git
 2. cd citrix-netscaler-triage
 3. pip install httpx
 4. python3 scan-citrix-netscaler-version.py --help
+
+In case of `uv`, you can run the script directly using:
+
+1. uv run https://raw.githubusercontent.com/fox-it/citrix-netscaler-triage/refs/heads/main/scan-citrix-netscaler-version.py
 
 Example usage:
 

--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -237,6 +237,7 @@ ssl_ctx = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 ssl_ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
 ssl_ctx.check_hostname = False
 ssl_ctx.verify_mode = ssl.CERT_NONE
+ssl_ctx.set_ciphers("ALL:@SECLEVEL=0")
 
 
 class NetScalerVersion(NamedTuple):


### PR DESCRIPTION
- Also output TLS subject names of the scanned server
- Added uv script dependencies
- Removed the --verify flag
- Fixed issue if the response body was empty