### PR TITLE
Add CVE and vulnerable status in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 This repository contains triage scripts for Citrix NetScaler devices:
 
 * `iocitrix.py` -- a Dissect script to Triage a Citrix NetScaler image/target.
-* `scan-citrix-netscaler-version.py` -- fingerprint the version of a Citrix NetScaler device over HTTP.
+* `scan-citrix-netscaler-version.py` -- Scan and fingerprint the version of a Citrix NetScaler device over HTTP(s).
 
 # scan-citrix-netscaler-version.py
 
-You can use this script to scan and determine the version of a Citrix NetScaler device over HTTP.
+You can use this script to scan and determine the version of a Citrix NetScaler device over HTTP(s).
+It will also determine if the NetScaler is vulnerable to specific CVEs based on the version.
 
 ## Installing `scan-citrix-netscaler-version.py`
 
@@ -18,7 +19,7 @@ Use the following steps if you are using pip:
 3. pip install httpx
 4. python3 scan-citrix-netscaler-version.py --help
 
-In case of `uv`, you can run the script directly using:
+In case of [uv](https://docs.astral.sh/uv/), you can run the script directly using:
 
 1. uv run https://raw.githubusercontent.com/fox-it/citrix-netscaler-triage/refs/heads/main/scan-citrix-netscaler-version.py
 
@@ -73,6 +74,7 @@ $ python3 scan-citrix-netscaler-version.py https://192.168.1.11 --cve CVE-2025-6
 }
 ```
 
+To get the results in CSV format, just use the `--csv` flag.
 For more options see `--help`.
 
 # iocitrix.py

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ In case of `uv`, you can run the script directly using:
 Example usage:
 
 ```shell
-$ python3 scan-citrix-netscaler-version.py 192.168.1.10
-192.168.1.10 is running Citrix NetScaler version 13.1-51.15
+$ python3 scan-citrix-netscaler-version.py 192.168.1.10 192.168.1.12
+192.168.1.10 (*.local.domain) is running Citrix NetScaler version 13.1-51.15 (VULNERABLE)
+192.168.1.12 (*.local.domain) is running Citrix NetScaler version 12.1-55.330 (NOT VULNERABLE)
 ```
 
 Or get the results in JSON:
@@ -34,12 +35,41 @@ Or get the results in JSON:
 ```shell
 $ python3 scan-citrix-netscaler-version.py https://192.168.1.11 --json | jq
 {
-  "scanned_at": "2024-05-13T13:37:08.039109+00:00",
+  "scanned_at": "2025-09-03T23:11:36.864228+00:00",
   "target": "https://192.168.1.11",
-  "rdx_en_stamp": 1702548756,
-  "rdx_en_dt": "2023-12-14T10:12:36+00:00",
-  "version": "13.0-92.21",
-  "error": null
+  "tls_names": "my-first-netscaler.local",
+  "rdx_en_stamp": 1702886392,
+  "rdx_en_dt": "2023-12-18T07:59:52+00:00",
+  "version": "12.1-55.302",
+  "error": null,
+  "vulnerable": {
+    "CVE-2025-5349": true,
+    "CVE-2025-5777": true,
+    "CVE-2025-6543": false,
+    "CVE-2025-7775": true,
+    "CVE-2025-7776": true,
+    "CVE-2025-8424": true
+  },
+  "is_vulnerable": true
+}
+```
+
+It's also possible to limit vulnerability status checks to specific CVEs by using the `--cve` flag:
+
+```shell
+$ python3 scan-citrix-netscaler-version.py https://192.168.1.11 --cve CVE-2025-6543 --json | jq
+{
+  "scanned_at": "2025-09-03T23:16:36.573016+00:00",
+  "target": "https://192.168.1.11",
+  "tls_names": "my-first-netscaler.local",
+  "rdx_en_stamp": 1702886392,
+  "rdx_en_dt": "2023-12-18T07:59:52+00:00",
+  "version": "12.1-55.302",
+  "error": null,
+  "vulnerable": {
+    "CVE-2025-6543": false
+  },
+  "is_vulnerable": false
 }
 ```
 

--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -378,7 +378,7 @@ def is_fips_13_1(vtuple: VersionTuple) -> bool:
 
     >>> is_fips_13_1(parse_version("13.1-37-241"))
     True
-    >>> is_fips_12_1(parse_version("13.1-9.60"))
+    >>> is_fips_13_1(parse_version("13.1-9.60"))
     False
     """
     return (vtuple.major, vtuple.minor, vtuple.build) == (13, 1, 37)  # fips, ndcpp

--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -758,7 +758,6 @@ def main() -> None:
             )
             jdict.update(version._asdict())
             jdict.update({"vulnerable": vulnerable_map})
-            is_vulnerable = any(vulnerable_map.values()) if vulnerable_map else False
             jdict.update({"is_vulnerable": is_vulnerable})
 
             if args.csv:

--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -13,6 +13,8 @@
 # This script scans a remote Citrix NetScaler device to determine the version based on a GZIP timestamp in a resource file.
 # The version hash is not always present anymore since our blog, so we need to rely on this timestamp metadata.
 #
+# It will also determine if the NetScaler is vulnerable to specific CVEs based on the version.
+#
 # Blog on how to fingerprint Citrix NetScaler devices using timestamp metadata of a GZIP file or hash:
 #  - https://blog.fox-it.com/2022/12/28/cve-2022-27510-cve-2022-27518-measuring-citrix-adc-gateway-version-adoption-on-the-internet/
 #
@@ -305,27 +307,27 @@ KYELLOW = "\x1b[33m"
 KNORM = "\033[0m"
 
 
-def bold(text):
+def bold(text: str) -> str:
     return KBOLD + text + KNORM
 
 
-def cyan(text):
+def cyan(text: str) -> str:
     return KCYAN + text + KNORM
 
 
-def green(text):
+def green(text: str) -> str:
     return KGREEN + text + KNORM
 
 
-def red(text):
+def red(text: str) -> str:
     return KRED + text + KNORM
 
 
-def yellow(text):
+def yellow(text: str) -> str:
     return KYELLOW + text + KNORM
 
 
-def nocolor(text):
+def nocolor(text: str) -> str:
     return text
 
 
@@ -344,7 +346,7 @@ def temporary_ssl_verify_mode(ssl_ctx: ssl.SSLContext, new_mode: ssl.VerifyMode)
 
 
 # ============================================================================
-# Vulnerability check functions
+# Vulnerability check logic
 # ============================================================================
 class VersionTuple(NamedTuple):
     major: int


### PR DESCRIPTION
The CVE checks are done against the determined NetScaler version.

- Use --csv option for CSV output
- Use --cve option to limit CVE checks
- CVE check functions have a docstring that is tested before running