### PR TITLE
Update scan-citrix-netscaler-version.py

### DIFF
--- a/scan-citrix-netscaler-version.py
+++ b/scan-citrix-netscaler-version.py
@@ -712,7 +712,7 @@ def main() -> None:
     for cve in cves_to_check:
         if cve not in available_cves:
             parser.error(
-                f"Unknown CVE: {cve!r}, available CVEs are:\n - {"\n - ".join(available_cves)}"
+                f"Unknown CVE: {cve!r}, available CVEs are:\n - " + "\n - ".join(available_cves)
             )
 
     client = httpx.Client(verify=ssl_ctx, timeout=args.timeout)


### PR DESCRIPTION
Error happening because f-strings treat {} as Python expressions, and you accidentally put double quotes " inside those braces. Python thought those quotes were closing the outer f-string, so it blew up with a syntax error.

Fix: Always use single quotes inside the braces (e.g. {' - '.join(items)}) or break the string into pieces.

That’s it,  the issue was just quote collision inside f-strings.